### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is the system repository for the NHS COVID-19 App System that uses the Goog
 It includes:
 
 * The [architecture guidebook](doc/architecture/ag-architecture-guidebook.md) for the complete CV-19 App System
-* The [API contracts](doc/design/api-contracts) for all exposed endpoints based on a small number of [patterns](doc/design/api-patterns.md).
+* The [API contracts](doc/architecture/api-contracts) for all exposed endpoints based on a small number of [patterns](doc/architecture/ag-architecture-guidebook.md).
 * The [provisioning scripts](tools/provisioning/dev) for the development environment
 * The scripts that setup the target environment and deploy the application code
 * The implementation of all services required to collect data and interact with the mobile devices and external systems


### PR DESCRIPTION
These were broken in https://github.com/nhsx/covid19-app-system-public/commit/a41ee3c966c4f59ff0b1e7c3ff8aeb70b1c2d312.

Fixes #3.